### PR TITLE
feat: improve Layout + add scrollable

### DIFF
--- a/packages/app/src/systems/Bridge/pages/Bridge.tsx
+++ b/packages/app/src/systems/Bridge/pages/Bridge.tsx
@@ -5,7 +5,9 @@ import { Layout } from '~/systems/Core';
 export const Bridge = () => {
   return (
     <Layout>
-      <Text>Bridge</Text>
+      <Layout.Content>
+        <Text>Bridge</Text>
+      </Layout.Content>
     </Layout>
   );
 };

--- a/packages/app/src/systems/Core/components/Layout.tsx
+++ b/packages/app/src/systems/Core/components/Layout.tsx
@@ -1,18 +1,45 @@
+import type { ThemeUtilsCSS } from '@fuel-ui/css';
 import { cssObj } from '@fuel-ui/css';
 import { Box } from '@fuel-ui/react';
-import type { ReactNode } from 'react';
+import type { FC, ReactNode } from 'react';
 import { Helmet } from 'react-helmet';
+
+import { coreStyles } from '../styles';
 
 import { Header } from './Header';
 
 import { META_DESC, META_OGIMG } from '~/constants';
+import { OverlayDialog } from '~/systems/Overlay';
+
+type ContentProps = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  as?: any;
+  children: ReactNode;
+  css?: ThemeUtilsCSS;
+};
+
+const Content = ({ as, children, css }: ContentProps) => {
+  return (
+    <Box
+      as={as}
+      css={{ ...styles.content, ...css }}
+      className="layout__content"
+    >
+      {children}
+    </Box>
+  );
+};
+
+type LayoutComponent = FC<LayoutProps> & {
+  Content: typeof Content;
+};
 
 type LayoutProps = {
   title?: string;
   children: ReactNode;
 };
 
-export function Layout({ title, children }: LayoutProps) {
+export const Layout: LayoutComponent = ({ title, children }: LayoutProps) => {
   const titleText = title || '';
   return (
     <>
@@ -23,26 +50,26 @@ export function Layout({ title, children }: LayoutProps) {
         <meta property="og:description" content={META_DESC} />
         <meta property="og:image" content={META_OGIMG} />
       </Helmet>
-      <Box css={styles.root}>
+      <Box as="main" css={styles.root}>
         <Header />
+        <OverlayDialog />
         {children}
       </Box>
     </>
   );
-}
+};
+
+Layout.Content = Content;
 
 const styles = {
   root: cssObj({
     maxW: '100vw',
     height: '100vh',
-    display: 'grid',
-    gridTemplateColumns: '1fr',
-    gridTemplateRows: '80px auto',
-
-    '@xl': {
-      gridTemplateColumns: '0.75fr 2.5fr 0.75fr',
-      gridTemplateRows: '80px auto',
-      gridColumnGap: '$14',
-    },
+  }),
+  content: cssObj({
+    ...coreStyles.scrollable(),
+    padding: '$4',
+    maxWidth: 420,
+    margin: '0 auto',
   }),
 };

--- a/packages/app/src/systems/Core/styles/core.ts
+++ b/packages/app/src/systems/Core/styles/core.ts
@@ -1,0 +1,33 @@
+import { cssObj } from '@fuel-ui/css';
+
+export const scrollable = (
+  regularColor: string = '$gray1',
+  hoverColor: string = '$gray10'
+) =>
+  cssObj({
+    overflowY: 'overlay',
+    overflowX: 'hidden',
+    scrollBehavior: 'smooth',
+
+    '&::-webkit-scrollbar': {
+      width: '14px',
+      backgroundColor: 'transparent',
+    },
+    '&::-webkit-scrollbar-track': {
+      backgroundColor: 'transparent',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: regularColor,
+      opacity: 0.5,
+      border: '4px solid transparent',
+      borderRadius: '12px',
+      backgroundClip: 'content-box',
+    },
+    '&::-webkit-scrollbar-thumb:hover': {
+      backgroundColor: hoverColor,
+    },
+  });
+
+export const coreStyles = {
+  scrollable,
+};

--- a/packages/app/src/systems/Core/styles/index.ts
+++ b/packages/app/src/systems/Core/styles/index.ts
@@ -1,0 +1,1 @@
+export * from './core';


### PR DESCRIPTION
## improve `Layout`component

#### include `Layout.Content`
now portal content will have width of: 420px
this is fixed, but we can apply sizes layer if needs other layout sizes.

ability to create pages with:
```

export const Bridge = () => {
  return (
    <Layout>
      <Layout.Content>
        <Text>Bridge</Text>
      </Layout.Content>
    </Layout>
  );
};

```

## add coreStyles.scrollable, which allows us to easily create scrollable boxes:

```
const styles = {
  root: cssObj({
    ...coreStyles.scrollable(),
  })
};
```