### PR TITLE
chore: remove impl contracts config

### DIFF
--- a/packages/app/load.envs.js
+++ b/packages/app/load.envs.js
@@ -35,7 +35,7 @@ function getEthFuelL1Contracts() {
     return {
       FuelChainState: '0xbe7aB12653e705642eb42EF375fd0d35Cfc45b03',
       FuelMessagePortal: '0x03f2901Db5723639978deBed3aBA66d4EA03aF73',
-      FuelERC20Gateway: '0x0C817d089c693Ea435a95c52409984F45847F53c'
+      FuelERC20Gateway: '0x0C817d089c693Ea435a95c52409984F45847F53c',
     };
   }
 }

--- a/packages/app/load.envs.js
+++ b/packages/app/load.envs.js
@@ -35,10 +35,7 @@ function getEthFuelL1Contracts() {
     return {
       FuelChainState: '0xbe7aB12653e705642eb42EF375fd0d35Cfc45b03',
       FuelMessagePortal: '0x03f2901Db5723639978deBed3aBA66d4EA03aF73',
-      FuelERC20Gateway: '0x0C817d089c693Ea435a95c52409984F45847F53c',
-      FuelChainState_impl: '0x9fe3f180aa29Cd49a73e99129A988F36A5800ADa',
-      FuelMessagePortal_impl: '0xaf4EBaF4D853809D984d4ee3D6DAA8fa2367396A',
-      FuelERC20Gateway_impl: '0xea8BE566210aE54687bFA3b0BF8Ddc3e49767655',
+      FuelERC20Gateway: '0x0C817d089c693Ea435a95c52409984F45847F53c'
     };
   }
 }


### PR DESCRIPTION
remove configs for "impl" contracts as they're not used