### PR TITLE
fix: bugfix + e2e tests improvements

### DIFF
--- a/packages/app/playwright/commons/locator.ts
+++ b/packages/app/playwright/commons/locator.ts
@@ -5,7 +5,7 @@ export function getByAriaLabel(page: Page, selector: string) {
 }
 
 export async function waitAriaLabel(page: Page, selector: string) {
-  return page.waitForSelector(`[aria-label="${selector}"]`);
+  return page.waitForSelector(`[aria-label*="${selector}"]`);
 }
 
 export function getInputByName(page: Page, name: string) {

--- a/packages/app/playwright/e2e/AssetList.test.ts
+++ b/packages/app/playwright/e2e/AssetList.test.ts
@@ -1,12 +1,8 @@
-import type { Page } from '@playwright/test';
 import test, { expect } from '@playwright/test';
 
 import { getButtonByText, getByAriaLabel, hasText } from '../commons';
 
-const hasDropdownSymbol = async (page: Page, symbol: string) => {
-  const assetDropdown = getByAriaLabel(page, 'Coin Selector').getByText(symbol);
-  expect(await assetDropdown.innerText()).toBe(symbol);
-};
+import { hasDropdownSymbol } from './utils/bridge';
 
 test.describe('Asset List', () => {
   test.beforeEach(async ({ page }) => {

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -627,7 +627,6 @@ test.describe('Bridge', () => {
       const balance = getByAriaLabel(page, 'Balance: ');
       const balanceText = await balance.innerText();
 
-      console.log(`balanceText`, balanceText);
       // refresh the page
       await page.goto('/bridge');
 
@@ -637,10 +636,10 @@ test.describe('Bridge', () => {
       );
       const addressAfterRefresh = await connectedWalletAferRefresh.innerText();
       const balanceAfterRefresh = getByAriaLabel(page, 'Balance: ');
-      const balanceTextAfterRefresh = await balance.innerText();
+      const balanceTextAfterRefresh = await balanceAfterRefresh.innerText();
 
       expect(addressAfterRefresh).toEqual(address);
-      expect(balanceTextAfterRefresh).toEqual(balanceAfterRefresh);
+      expect(balanceTextAfterRefresh).toEqual(balanceText);
     });
   });
 });

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -374,7 +374,6 @@ test.describe('Bridge', () => {
         await hasDropdownSymbol(page, 'TKN');
         // Deposit asset
         const depositButton = getByAriaLabel(page, 'Deposit');
-        expect(await depositButton.innerText()).toBe('Enter amount');
 
         const depositInput = page.locator('input');
         await depositInput.fill(DEPOSIT_AMOUNT);

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -20,7 +20,14 @@ import {
 import { ETH_MNEMONIC, FUEL_MNEMONIC } from '../mocks';
 
 import { test, expect } from './fixtures';
-import { closeTransactionPopup } from './utils/bridge';
+import {
+  clickDepositTab,
+  clickWithdrawTab,
+  closeTransactionPopup,
+  goToBridgePage,
+  goToTransactionsPage,
+  hasDropdownSymbol,
+} from './utils/bridge';
 
 const { FUEL_PROVIDER_URL, VITE_ETH_ERC20, VITE_FUEL_FUNGIBLE_ASSET_ID } =
   process.env;
@@ -83,6 +90,8 @@ test.describe('Bridge', () => {
       'Deposit successfully initiated. You may now close the popup.';
     const INITIATE_WITHDRAW =
       'Withdraw successfully initiated. You may now close the popup.';
+    const DEPOSIT_AMOUNT = '1.12345';
+    const WITHDRAW_AMOUNT = '0.012345';
 
     await test.step('Deposit ETH to Fuel', async () => {
       const preDepositBalanceFuel = await fuelWallet.getBalance(BaseAssetId);
@@ -90,217 +99,258 @@ test.describe('Bridge', () => {
         address: account.address,
       });
 
-      // Deposit asset
-      const depositAmount = '1.12345';
-      const depositInput = page.locator('input');
-      await depositInput.fill(depositAmount);
-      const depositButton = getByAriaLabel(page, 'Deposit');
-      await depositButton.click();
-
-      // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
-      await page.waitForTimeout(2000);
-      await metamask.confirmTransaction();
-
-      await page.locator(':nth-match(:text("Done"), 1)').waitFor();
-      await hasText(page, INITIATE_DEPOSIT);
-
-      // Check steps
-      await page.locator(':nth-match(:text("Done"), 3)').waitFor();
-
-      const postDepositBalanceEth = await client.getBalance({
-        address: account.address,
+      await test.step('Fill data and click on deposit', async () => {
+        await hasDropdownSymbol(page, 'ETH');
+        const depositInput = page.locator('input');
+        await depositInput.fill(DEPOSIT_AMOUNT);
+        const depositButton = getByAriaLabel(page, 'Deposit');
+        await depositButton.click();
       });
 
-      expect(
-        parseFloat(
-          bn(prevDepositBalanceEth.toString())
-            .sub(postDepositBalanceEth.toString())
-            .format({ precision: 6, units: 18 })
-        )
-      ).toBeCloseTo(parseFloat(depositAmount));
+      await test.step('Approve transaction on Metamask', async () => {
+        // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
+        await page.waitForTimeout(2000);
+        await metamask.confirmTransaction();
+      });
 
-      // check the popup is correct
-      const transactionID = (
-        await getByAriaLabel(page, 'Transaction ID').innerText()
-      ).trim();
-      const assetAmount = getByAriaLabel(page, 'Asset amount');
-      expect((await assetAmount.innerHTML()).trim()).toBe(depositAmount);
-      await closeTransactionPopup(page);
+      await test.step('Check transaction submitted to ETH network', async () => {
+        // Check if has loading state on dialog
+        const loading = getByAriaLabel(page, 'Loading Transaction Info');
+        const innerTexts = await loading.allInnerTexts();
+        expect(innerTexts.length).toBe(2);
 
-      const postDepositBalanceFuel = await fuelWallet.getBalance(BaseAssetId);
+        await page.locator(':nth-match(:text("Done"), 1)').waitFor();
 
-      expect(
-        postDepositBalanceFuel
-          .sub(preDepositBalanceFuel)
-          .format({ precision: 6, units: 9 })
-      ).toBe(depositAmount);
+        // Check toast success feedback of tx created
+        await hasText(page, INITIATE_DEPOSIT);
+      });
 
-      // Go to transaction page
-      const transactionList = page.locator('button').getByText('History');
-      await transactionList.click();
+      let transactionID: string;
+      await test.step('Check if deposit is completed', async () => {
+        await page.locator(':nth-match(:text("Done"), 3)').waitFor();
 
-      // check the transaction is there
-      const depositLocator = getByAriaLabel(
-        page,
-        `Transaction ID: ${transactionID}`
-      );
+        const postDepositBalanceEth = await client.getBalance({
+          address: account.address,
+        });
 
-      // check if has correct asset amount
-      const assetAmountLocator = depositLocator.getByText(
-        `${depositAmount} ETH`
-      );
-      await assetAmountLocator.innerText();
+        expect(
+          parseFloat(
+            bn(prevDepositBalanceEth.toString())
+              .sub(postDepositBalanceEth.toString())
+              .format({ precision: 6, units: 18 })
+          )
+        ).toBeCloseTo(parseFloat(DEPOSIT_AMOUNT));
 
-      // check if it's settled on the list
-      const statusLocator = depositLocator.getByText(`Settled`);
-      await statusLocator.innerText();
+        // check the popup is correct
+        transactionID = (
+          await getByAriaLabel(page, 'Transaction ID').innerText()
+        ).trim();
+        const assetAmount = getByAriaLabel(page, 'Asset amount');
+        expect((await assetAmount.innerHTML()).trim()).toBe(DEPOSIT_AMOUNT);
+      });
+
+      await test.step('Check deposit tx in the Tx list', async () => {
+        await closeTransactionPopup(page);
+
+        const postDepositBalanceFuel = await fuelWallet.getBalance(BaseAssetId);
+
+        expect(
+          postDepositBalanceFuel
+            .sub(preDepositBalanceFuel)
+            .format({ precision: 6, units: 9 })
+        ).toBe(DEPOSIT_AMOUNT);
+
+        await goToTransactionsPage(page);
+
+        // check the transaction is there
+        const depositLocator = getByAriaLabel(
+          page,
+          `Transaction ID: ${transactionID}`
+        );
+
+        // check if has correct asset amount
+        const assetAmountLocator = depositLocator.getByText(
+          `${DEPOSIT_AMOUNT} ETH`
+        );
+        await assetAmountLocator.innerText();
+
+        // check if it's settled on the list
+        const statusLocator = depositLocator.getByText(`Settled`);
+        await statusLocator.innerText();
+
+        goToBridgePage(page);
+      });
     });
 
-    await test.step('Withdraw ETH from Fuel to ETH', async () => {
-      // Go to transaction page
-      const transactionList = page.locator('button').getByText('History');
-
-      // Go to the bridge page
-      bridgePage = page.locator('button').getByText('Bridge');
-      await bridgePage.click();
-
-      // Go to the withdraw page
-      const withdrawPage = getButtonByText(page, 'Withdraw from Fuel');
-      await withdrawPage.click();
-
+    await test.step('Withdraw ETH from Fuel', async () => {
       const preWithdrawBalanceFuel = await fuelWallet.getBalance(BaseAssetId);
       const prevWithdrawBalanceEth = await client.getBalance({
         address: account.address,
       });
 
-      // Withdraw asset
-      const withdrawAmount = '0.012345';
-      const withdrawInput = page.locator('input');
-      await withdrawInput.fill(withdrawAmount);
-      const withdrawButton = getByAriaLabel(page, 'Withdraw');
-      await withdrawButton.click();
-      await walletApprove(context);
-
-      await page.locator(':nth-match(:text("Done"), 1)').waitFor();
-      await hasText(page, INITIATE_WITHDRAW);
-
-      await page.locator(':text("Action Required")').waitFor();
-
-      // Check the popup is correct
-      const transactionID = (
-        await getByAriaLabel(page, 'Transaction ID').innerText()
-      ).trim();
-      const assetAmountWithdraw = getByAriaLabel(page, 'Asset amount');
-      expect((await assetAmountWithdraw.innerHTML()).trim()).toBe(
-        withdrawAmount
-      );
-      await closeTransactionPopup(page);
-
-      // Go to the transaction page
-      await transactionList.click();
-
-      // Wait for transactions to get fetched and sorted
-      await page.waitForTimeout(2000);
-
-      // Check the transaction is there
-      const withdrawLocator = getByAriaLabel(
-        page,
-        `Transaction ID: ${transactionID}`
-      );
-
-      const assetAmountLocator = withdrawLocator.getByText(
-        `${withdrawAmount} ETH`
-      );
-      await assetAmountLocator.innerText();
-
-      await assetAmountLocator.click();
-      await page.waitForTimeout(10000);
-      const confirmButton = getButtonByText(page, 'Confirm Transaction');
-      await confirmButton.click();
-
-      // For some reason we need this even if we wait for load state on the metamask notification page
-      await page.waitForTimeout(3000);
-
-      let metamaskNotificationPage = context
-        .pages()
-        .find((p) => p.url().includes('notification'));
-      if (!metamaskNotificationPage) {
-        metamaskNotificationPage = await context.waitForEvent('page', {
-          predicate: (page) => page.url().includes('notification'),
-        });
-      }
-      const proceedAnyways = metamaskNotificationPage.getByText(
-        'I want to proceed anyway'
-      );
-      const count = await proceedAnyways.count();
-      if (count) {
-        await proceedAnyways.click();
-      }
-
-      // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
-      await page.waitForTimeout(10000);
-      await metamask.confirmTransaction();
-
-      await closeTransactionPopup(page);
-
-      const postWithdrawBalanceEth = await client.getBalance({
-        address: account.address,
+      await test.step('Fill data and click on withdraw', async () => {
+        await clickWithdrawTab(page);
+        await hasDropdownSymbol(page, 'ETH');
+        const withdrawInput = page.locator('input');
+        await withdrawInput.fill(WITHDRAW_AMOUNT);
+        const withdrawButton = getByAriaLabel(page, 'Withdraw');
+        await withdrawButton.click();
       });
-      const postWithdrawBalanceFuel = await fuelWallet.getBalance(BaseAssetId);
 
-      // We only divide by 15 bc bigint does not support decimals
-      expect(
-        parseFloat(
-          bn(postWithdrawBalanceEth.toString())
-            .sub(bn(prevWithdrawBalanceEth.toString()))
-            .format({ precision: 6, units: 18 })
-        )
-      ).toBeCloseTo(0.0122);
+      await test.step('Approve transaction on Fuel Wallet', async () => {
+        await walletApprove(context);
+      });
 
-      expect(
-        preWithdrawBalanceFuel
-          .sub(postWithdrawBalanceFuel)
-          .format({ precision: 6, units: 9 })
-      ).toBe('0.012345');
+      await test.step('Check transaction submitted to FUEL network', async () => {
+        // On withdraw we skip checking loading because it's blazingly fast on fuel
+        await page.locator(':nth-match(:text("Done"), 1)').waitFor();
+
+        // Check toast success feedback of tx created
+        await hasText(page, INITIATE_WITHDRAW);
+      });
+
+      let transactionID: string;
+      await test.step('Check if get to relay action', async () => {
+        await page.locator(':text("Action Required")').waitFor();
+
+        // Check the popup is correct
+        transactionID = (
+          await getByAriaLabel(page, 'Transaction ID').innerText()
+        ).trim();
+        const assetAmountWithdraw = getByAriaLabel(page, 'Asset amount');
+        expect((await assetAmountWithdraw.innerHTML()).trim()).toBe(
+          WITHDRAW_AMOUNT
+        );
+      });
+
+      let withdrawTxLocator;
+      await test.step('Check withdraw tx in the Tx list and open popup', async () => {
+        await closeTransactionPopup(page);
+        await goToTransactionsPage(page);
+
+        // Wait for transactions to get fetched and sorted
+        await page.waitForTimeout(2000);
+
+        // Check the transaction is there
+        withdrawTxLocator = getByAriaLabel(
+          page,
+          `Transaction ID: ${transactionID}`
+        );
+
+        const assetAmountLocator = withdrawTxLocator.getByText(
+          `${WITHDRAW_AMOUNT} ETH`
+        );
+        await assetAmountLocator.innerText();
+
+        await assetAmountLocator.click();
+      });
+
+      await test.step('Relay transaction', async () => {
+        await page.waitForTimeout(10000);
+        const confirmButton = getButtonByText(page, 'Confirm Transaction');
+        await confirmButton.click();
+      });
+
+      await test.step('Confirm on Metamask', async () => {
+        // For some reason we need this even if we wait for load state on the metamask notification page
+        await page.waitForTimeout(3000);
+
+        let metamaskNotificationPage = context
+          .pages()
+          .find((p) => p.url().includes('notification'));
+        if (!metamaskNotificationPage) {
+          metamaskNotificationPage = await context.waitForEvent('page', {
+            predicate: (page) => page.url().includes('notification'),
+          });
+        }
+        const proceedAnyways = metamaskNotificationPage.getByText(
+          'I want to proceed anyway'
+        );
+        const count = await proceedAnyways.count();
+        if (count) {
+          await proceedAnyways.click();
+        }
+
+        // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
+        await page.waitForTimeout(10000);
+        await metamask.confirmTransaction();
+      });
+
+      await test.step('Check withdraw is completed', async () => {
+        const postWithdrawBalanceEth = await client.getBalance({
+          address: account.address,
+        });
+        const postWithdrawBalanceFuel = await fuelWallet.getBalance(
+          BaseAssetId
+        );
+
+        // We only divide by 15 bc bigint does not support decimals
+        expect(
+          parseFloat(
+            bn(postWithdrawBalanceEth.toString())
+              .sub(bn(prevWithdrawBalanceEth.toString()))
+              .format({ precision: 6, units: 18 })
+          )
+        ).toBeCloseTo(0.0122);
+
+        expect(
+          preWithdrawBalanceFuel
+            .sub(postWithdrawBalanceFuel)
+            .format({ precision: 6, units: 9 })
+        ).toBe('0.012345');
+
+        await closeTransactionPopup(page);
+
+        // check if it's settled on the list
+        const statusLocator = withdrawTxLocator.getByText(`Settled`);
+        await statusLocator.innerText();
+      });
     });
 
     await test.step('Faucet TKN', async () => {
-      // Go to the bridge page
-      bridgePage = page.locator('button').getByText('Bridge');
-      await bridgePage.click();
-      // Go to the deposit page
-      const depositPage = getButtonByText(page, 'Deposit to Fuel');
-      await depositPage.click();
-
       erc20Contract = getContract({
         abi: ERC_20.abi,
         address: VITE_ETH_ERC20 as `0x${string}`,
         publicClient: client,
       });
-
       const preFaucetBalance = (await erc20Contract.read.balanceOf([
         account.address,
       ])) as BigNumberish;
 
-      const coinSelector = getByAriaLabel(page, 'Coin Selector');
-      await coinSelector.click();
+      await test.step('Go to deposit tab', async () => {
+        await goToBridgePage(page);
+        await clickDepositTab(page);
+      });
 
-      const faucetButton = getByAriaLabel(page, 'Faucet Eth Asset');
-      await faucetButton.click();
+      await test.step('Faucet ERC-20', async () => {
+        const coinSelector = getByAriaLabel(page, 'Coin Selector');
+        await coinSelector.click();
 
-      // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
-      await page.waitForTimeout(2000);
-      await metamask.confirmTransaction();
+        const faucetButton = getByAriaLabel(page, 'Faucet Eth Asset');
+        await faucetButton.click();
+      });
 
-      const postFaucetBalance = await erc20Contract.read.balanceOf([
-        account.address,
-      ]);
-      expect(String(postFaucetBalance)).toBe(
-        bn(preFaucetBalance).add(bn.parseUnits('1000000', 18)).toString()
-      );
+      await test.step('Confirm on Metamask', async () => {
+        // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
+        await page.waitForTimeout(2000);
+        await metamask.confirmTransaction();
+      });
 
-      const tknButton = page.getByRole('button', { name: 'TKN' });
-      await tknButton.click();
+      let postFaucetBalance;
+      await test.step('Check faucet worked', async () => {
+        postFaucetBalance = await erc20Contract.read.balanceOf([
+          account.address,
+        ]);
+        expect(String(postFaucetBalance)).toBe(
+          bn(preFaucetBalance).add(bn.parseUnits('1000000', 18)).toString()
+        );
+      });
+
+      await test.step('Select TKN', async () => {
+        const tknButton = page.getByRole('button', { name: 'TKN' });
+        await tknButton.click();
+        await hasDropdownSymbol(page, 'TKN');
+      });
 
       await hasText(
         page,
@@ -318,199 +368,245 @@ test.describe('Bridge', () => {
       const preDepositBalanceEth = await erc20Contract.read.balanceOf([
         account.address,
       ]);
+      const DEPOSIT_AMOUNT = '1.12345';
 
-      // Deposit asset
-      const depositAmount = '1.12345';
-      const depositInput = page.locator('input');
-      await depositInput.fill(depositAmount);
-      const depositButton = getByAriaLabel(page, 'Deposit');
-      await depositButton.click();
+      await test.step('Fill data and click on deposit', async () => {
+        await hasDropdownSymbol(page, 'TKN');
+        // Deposit asset
+        const depositButton = getByAriaLabel(page, 'Deposit');
+        expect(await depositButton.innerText()).toBe('Enter amount');
 
-      // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
-      await page.waitForTimeout(7500);
-      await metamask.confirmPermissionToSpend();
-      await metamask.confirmTransaction();
-
-      await page.locator(':nth-match(:text("Done"), 1)').waitFor();
-      await hasText(page, INITIATE_DEPOSIT);
-
-      // Check steps
-      await page.locator(':nth-match(:text("Done"), 2)').waitFor();
-
-      const postDepositBalanceEth = await erc20Contract.read.balanceOf([
-        account.address,
-      ]);
-
-      expect(
-        parseFloat(
-          bn(preDepositBalanceEth.toString())
-            .sub(postDepositBalanceEth.toString())
-            .format({ precision: 6, units: 18 })
-        )
-      ).toBeCloseTo(parseFloat(depositAmount));
-
-      // check the popup is correct
-      const transactionID = (
-        await getByAriaLabel(page, 'Transaction ID').innerText()
-      ).trim();
-      const assetAmount = getByAriaLabel(page, 'Asset amount');
-      expect((await assetAmount.innerHTML()).trim()).toBe(depositAmount);
-      await closeTransactionPopup(page);
-
-      const transactionList = page.locator('button').getByText('History');
-      await transactionList.click();
-
-      // check the transaction is there
-      const depositLocator = getByAriaLabel(
-        page,
-        `Transaction ID: ${transactionID}`
-      );
-      // Check that action required is shown
-      const actionRequiredLocator = depositLocator.getByText('Action Required');
-      await actionRequiredLocator.innerText();
-      // check if has correct asset amount
-      const assetAmountLocator = depositLocator.getByText(
-        `${depositAmount} TKN`
-      );
-      await assetAmountLocator.innerText();
-
-      // Confirm the transaction on the fuel side
-      await depositLocator.click();
-      const confirmTransactionButton = page.getByRole('button', {
-        name: 'Confirm Transaction',
+        const depositInput = page.locator('input');
+        await depositInput.fill(DEPOSIT_AMOUNT);
+        await depositButton.click();
       });
-      await confirmTransactionButton.click();
-      await walletApprove(context);
 
-      // Check steps
-      await page.locator(':nth-match(:text("Done"), 4)').waitFor();
-      await closeTransactionPopup(page);
+      await test.step('Approve transaction on Metamask', async () => {
+        // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
+        await page.waitForTimeout(7500);
+        await metamask.confirmPermissionToSpend();
+        await metamask.confirmTransaction();
+      });
 
-      const postDepositBalanceFuel = await fuelWallet.getBalance(
-        VITE_FUEL_FUNGIBLE_ASSET_ID
-      );
+      await test.step('Check transaction submitted to ETH network', async () => {
+        // Check if has loading state on dialog
+        const loading = getByAriaLabel(page, 'Loading Transaction Info');
+        expect((await loading.allInnerTexts()).length).toBe(2);
 
-      expect(
-        postDepositBalanceFuel
-          .sub(preDepositBalanceFuel)
-          .format({ precision: 6, units: 9 })
-      ).toBe(depositAmount);
+        await page.locator(':nth-match(:text("Done"), 1)').waitFor();
 
-      // check if it's settled on the list
-      const statusLocator = depositLocator.getByText(`Settled`);
-      await statusLocator.innerText();
+        // Check toast success feedback of tx created
+        await hasText(page, INITIATE_DEPOSIT);
+      });
+
+      await test.step('Check ETH balance reduced', async () => {
+        await page.locator(':nth-match(:text("Done"), 2)').waitFor();
+
+        const postDepositBalanceEth = await erc20Contract.read.balanceOf([
+          account.address,
+        ]);
+
+        expect(
+          parseFloat(
+            bn(preDepositBalanceEth.toString())
+              .sub(postDepositBalanceEth.toString())
+              .format({ precision: 6, units: 18 })
+          )
+        ).toBeCloseTo(parseFloat(DEPOSIT_AMOUNT));
+      });
+
+      let transactionID: string;
+      await test.step('Check if deposit reach relay step', async () => {
+        transactionID = (
+          await getByAriaLabel(page, 'Transaction ID').innerText()
+        ).trim();
+        const assetAmount = getByAriaLabel(page, 'Asset amount');
+        expect((await assetAmount.innerHTML()).trim()).toBe(DEPOSIT_AMOUNT);
+      });
+
+      let depositTxLocator;
+      await test.step('Check withdraw tx in the Tx list and open popup', async () => {
+        await closeTransactionPopup(page);
+        await goToTransactionsPage(page);
+
+        // check the transaction is there
+        depositTxLocator = getByAriaLabel(
+          page,
+          `Transaction ID: ${transactionID}`
+        );
+        // Check that action required is shown
+        const actionRequiredLocator =
+          depositTxLocator.getByText('Action Required');
+        await actionRequiredLocator.innerText();
+        // check if has correct asset amount
+        const assetAmountLocator = depositTxLocator.getByText(
+          `${DEPOSIT_AMOUNT} TKN`
+        );
+        await assetAmountLocator.innerText();
+
+        // Confirm the transaction on the fuel side
+        await depositTxLocator.click();
+      });
+
+      await test.step('Relay transaction', async () => {
+        const confirmTransactionButton = page.getByRole('button', {
+          name: 'Confirm Transaction',
+        });
+        await confirmTransactionButton.click();
+      });
+
+      await test.step('Confirm on Fuel Wallet', async () => {
+        await walletApprove(context);
+      });
+
+      await test.step('Check deposit is completed', async () => {
+        await page.locator(':nth-match(:text("Done"), 4)').waitFor();
+        await closeTransactionPopup(page);
+
+        const postDepositBalanceFuel = await fuelWallet.getBalance(
+          VITE_FUEL_FUNGIBLE_ASSET_ID
+        );
+
+        expect(
+          postDepositBalanceFuel
+            .sub(preDepositBalanceFuel)
+            .format({ precision: 6, units: 9 })
+        ).toBe(DEPOSIT_AMOUNT);
+
+        // check if it's settled on the list
+        const statusLocator = depositTxLocator.getByText(`Settled`);
+        await statusLocator.innerText();
+      });
     });
 
     await test.step('Withdraw TKN from Fuel to ETH', async () => {
-      // Go to the bridge page
-      bridgePage = page.locator('button').getByText('Bridge');
-      await bridgePage.click();
-
-      // Go to the withdraw page
-      const withdrawPage = getButtonByText(page, 'Withdraw from Fuel');
-      await withdrawPage.click();
-
       const preWithdrawBalanceFuel = await fuelWallet.getBalance(
         VITE_FUEL_FUNGIBLE_ASSET_ID
       );
       const preWithdrawBalanceEth = await erc20Contract.read.balanceOf([
         account.address,
       ]);
+      const WITHDRAW_AMOUNT = '0.012345';
 
-      // Withdraw asset
-      const withdrawAmount = '0.012345';
-      const withdrawInput = page.locator('input');
-      await withdrawInput.fill(withdrawAmount);
-      const withdrawButton = getByAriaLabel(page, 'Withdraw');
-      await withdrawButton.click();
-      await page.waitForTimeout(2500);
-      await walletApprove(context);
+      await test.step('Fill data and click on withdraw', async () => {
+        await goToBridgePage(page);
+        await clickWithdrawTab(page);
+        await hasDropdownSymbol(page, 'TKN');
+        const withdrawInput = page.locator('input');
+        await withdrawInput.fill(WITHDRAW_AMOUNT);
+        const withdrawButton = getByAriaLabel(page, 'Withdraw');
+        await withdrawButton.click();
+      });
 
-      await page.locator(':nth-match(:text("Done"), 1)').waitFor();
-      await hasText(page, INITIATE_WITHDRAW);
+      await test.step('Approve transaction on Fuel Wallet', async () => {
+        await page.waitForTimeout(2500);
+        await walletApprove(context);
+      });
 
-      await page.locator(':text("Action Required")').waitFor();
+      await test.step('Check transaction submitted to FUEL network', async () => {
+        // On withdraw we skip checking loading because it's blazingly fast on fuel
+        await page.locator(':nth-match(:text("Done"), 1)').waitFor();
 
-      // Check the popup is correct
-      const transactionID = (
-        await getByAriaLabel(page, 'Transaction ID').innerText()
-      ).trim();
-      const assetAmountWithdraw = getByAriaLabel(page, 'Asset amount');
-      expect((await assetAmountWithdraw.innerHTML()).trim()).toBe(
-        withdrawAmount
-      );
-      await closeTransactionPopup(page);
+        // Check toast success feedback of tx created
+        await hasText(page, INITIATE_WITHDRAW);
+      });
 
-      // Go to transaction page
-      const transactionList = page.locator('button').getByText('History');
-      await transactionList.click();
+      let transactionID: string;
+      await test.step('Check if get to relay action', async () => {
+        await page.locator(':text("Action Required")').waitFor();
 
-      // Wait for transactions to get fetched and sorted
-      await page.waitForTimeout(2000);
+        // Check the popup is correct
+        transactionID = (
+          await getByAriaLabel(page, 'Transaction ID').innerText()
+        ).trim();
+        const assetAmountWithdraw = getByAriaLabel(page, 'Asset amount');
+        expect((await assetAmountWithdraw.innerHTML()).trim()).toBe(
+          WITHDRAW_AMOUNT
+        );
+      });
 
-      // Check the transaction is there
-      const withdrawLocator = getByAriaLabel(
-        page,
-        `Transaction ID: ${transactionID}`
-      );
+      let withdrawTxLocator;
+      await test.step('Check withdraw tx in the Tx list and open popup', async () => {
+        await closeTransactionPopup(page);
+        await goToTransactionsPage(page);
 
-      const actionRequiredLocator =
-        withdrawLocator.getByText('Action Required');
-      await actionRequiredLocator.innerText();
-      const assetAmountLocator = withdrawLocator.getByText(
-        `${withdrawAmount} TKN`
-      );
-      await assetAmountLocator.innerText();
+        // Wait for transactions to get fetched and sorted
+        await page.waitForTimeout(2000);
 
-      await assetAmountLocator.click();
-      const confirmButton = getButtonByText(page, 'Confirm Transaction');
-      await confirmButton.click();
+        // Check the transaction is there
+        withdrawTxLocator = getByAriaLabel(
+          page,
+          `Transaction ID: ${transactionID}`
+        );
 
-      // For some reason we need this even if we wait for load state on the metamask notification page
-      await page.waitForTimeout(3000);
+        const actionRequiredLocator =
+          withdrawTxLocator.getByText('Action Required');
+        await actionRequiredLocator.innerText();
+        const assetAmountLocator = withdrawTxLocator.getByText(
+          `${WITHDRAW_AMOUNT} TKN`
+        );
+        await assetAmountLocator.innerText();
 
-      let metamaskNotificationPage = context
-        .pages()
-        .find((p) => p.url().includes('notification'));
-      if (!metamaskNotificationPage) {
-        metamaskNotificationPage = await context.waitForEvent('page', {
-          predicate: (page) => page.url().includes('notification'),
-        });
-      }
-      const proceedAnyways = metamaskNotificationPage.getByText(
-        'I want to proceed anyway'
-      );
-      const count = await proceedAnyways.count();
-      if (count) {
-        await proceedAnyways.click();
-      }
+        await assetAmountLocator.click();
+      });
 
-      // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
-      await page.waitForTimeout(5000);
-      await metamask.confirmTransaction();
+      await test.step('Relay transaction', async () => {
+        const confirmButton = getButtonByText(page, 'Confirm Transaction');
+        await confirmButton.click();
+      });
 
-      await closeTransactionPopup(page);
+      await test.step('Confirm on Metamask', async () => {
+        // For some reason we need this even if we wait for load state on the metamask notification page
+        await page.waitForTimeout(3000);
 
-      const postWithdrawBalanceEth = await erc20Contract.read.balanceOf([
-        account.address,
-      ]);
-      const postWithdrawBalanceFuel = await fuelWallet.getBalance(
-        VITE_FUEL_FUNGIBLE_ASSET_ID
-      );
+        let metamaskNotificationPage = context
+          .pages()
+          .find((p) => p.url().includes('notification'));
+        if (!metamaskNotificationPage) {
+          metamaskNotificationPage = await context.waitForEvent('page', {
+            predicate: (page) => page.url().includes('notification'),
+          });
+        }
+        const proceedAnyways = metamaskNotificationPage.getByText(
+          'I want to proceed anyway'
+        );
+        const count = await proceedAnyways.count();
+        if (count) {
+          await proceedAnyways.click();
+        }
 
-      expect(
-        parseFloat(
-          bn(postWithdrawBalanceEth.toString())
-            .sub(bn(preWithdrawBalanceEth.toString()))
-            .format({ precision: 6, units: 18 })
-        )
-      ).toBeCloseTo(parseFloat(withdrawAmount));
+        // Timeout needed until https://github.com/Synthetixio/synpress/issues/795 is fixed
+        await page.waitForTimeout(5000);
+        await metamask.confirmTransaction();
+      });
 
-      expect(
-        preWithdrawBalanceFuel
-          .sub(postWithdrawBalanceFuel)
-          .format({ precision: 6, units: 9 })
-      ).toBe(withdrawAmount);
+      await test.step('Check withdraw is completed', async () => {
+        const postWithdrawBalanceEth = await erc20Contract.read.balanceOf([
+          account.address,
+        ]);
+        const postWithdrawBalanceFuel = await fuelWallet.getBalance(
+          VITE_FUEL_FUNGIBLE_ASSET_ID
+        );
+
+        expect(
+          parseFloat(
+            bn(postWithdrawBalanceEth.toString())
+              .sub(bn(preWithdrawBalanceEth.toString()))
+              .format({ precision: 6, units: 18 })
+          )
+        ).toBeCloseTo(parseFloat(WITHDRAW_AMOUNT));
+
+        expect(
+          preWithdrawBalanceFuel
+            .sub(postWithdrawBalanceFuel)
+            .format({ precision: 6, units: 9 })
+        ).toBe(WITHDRAW_AMOUNT);
+        await closeTransactionPopup(page);
+
+        // check if it's settled on the list
+        const statusLocator = withdrawTxLocator.getByText(`Settled`);
+        await statusLocator.innerText();
+      });
     });
   });
 });

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -603,19 +603,44 @@ test.describe('Bridge', () => {
       });
     });
 
-    await test.step('Validate Bridge Transaction List', async () => {
-      await test.step('Should show correct loading after refresh page', async () => {
-        await page.goto('/bridge');
-        await goToTransactionsPage(page);
+    await test.step('Transaction list should show correct after refresh the page', async () => {
+      await page.goto('/bridge');
+      await goToTransactionsPage(page);
 
-        const loading = getByAriaLabel(page, 'Loading Bridge Transactions');
-        await loading.innerText();
+      const loading = getByAriaLabel(page, 'Loading Bridge Transactions');
+      await loading.innerText();
 
-        await checkTxItemDone(page, depositEthTxId);
-        await checkTxItemDone(page, depositERC20TxId);
-        await checkTxItemDone(page, withdrawEthTxId);
-        await checkTxItemDone(page, withdrawERC20TxId);
-      });
+      await checkTxItemDone(page, depositEthTxId);
+      await checkTxItemDone(page, depositERC20TxId);
+      await checkTxItemDone(page, withdrawEthTxId);
+      await checkTxItemDone(page, withdrawERC20TxId);
+    });
+
+    await test.step('Fuel wallet should be connected after refresh', async () => {
+      await goToBridgePage(page);
+
+      const connectedWallet = getByAriaLabel(
+        page,
+        'Fuel Devnet: Connected Wallet'
+      );
+      const address = await connectedWallet.innerText();
+      const balance = getByAriaLabel(page, 'Balance: ');
+      const balanceText = await balance.innerText();
+
+      console.log(`balanceText`, balanceText);
+      // refresh the page
+      await page.goto('/bridge');
+
+      const connectedWalletAferRefresh = getByAriaLabel(
+        page,
+        'Fuel Devnet: Connected Wallet'
+      );
+      const addressAfterRefresh = await connectedWalletAferRefresh.innerText();
+      const balanceAfterRefresh = getByAriaLabel(page, 'Balance: ');
+      const balanceTextAfterRefresh = await balance.innerText();
+
+      expect(addressAfterRefresh).toEqual(address);
+      expect(balanceTextAfterRefresh).toEqual(balanceAfterRefresh);
     });
   });
 });

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -199,6 +199,10 @@ test.describe('Bridge', () => {
 
         // Check toast success feedback of tx created
         await hasText(page, INITIATE_WITHDRAW);
+
+        // check time left feedback
+        const stepSettlementLocator = getByAriaLabel(page, ' left');
+        await stepSettlementLocator.innerText();
       });
 
       let transactionID: string;
@@ -493,6 +497,10 @@ test.describe('Bridge', () => {
 
         // Check toast success feedback of tx created
         await hasText(page, INITIATE_WITHDRAW);
+
+        // check time left feedback
+        const stepSettlementLocator = getByAriaLabel(page, ' left');
+        await stepSettlementLocator.innerText();
       });
 
       let transactionID: string;

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -393,7 +393,7 @@ test.describe('Bridge', () => {
         await page.locator(':nth-match(:text("Done"), 2)').waitFor();
       });
 
-      await test.step('Check ETH balance reduced', async () => {
+      await test.step('Check ETH TKN balance reduced', async () => {
         const postDepositBalanceEth = await erc20Contract.read.balanceOf([
           account.address,
         ]);

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -113,20 +113,12 @@ test.describe('Bridge', () => {
         await metamask.confirmTransaction();
       });
 
-      await test.step('Check transaction submitted to ETH network', async () => {
-        // Check if has loading state on dialog
-        const loading = getByAriaLabel(page, 'Loading Transaction Info');
-        const innerTexts = await loading.allInnerTexts();
-        expect(innerTexts.length).toBe(2);
-
+      let transactionID: string;
+      await test.step('Check if deposit is completed', async () => {
         await page.locator(':nth-match(:text("Done"), 1)').waitFor();
 
         // Check toast success feedback of tx created
         await hasText(page, INITIATE_DEPOSIT);
-      });
-
-      let transactionID: string;
-      await test.step('Check if deposit is completed', async () => {
         await page.locator(':nth-match(:text("Done"), 3)').waitFor();
 
         const postDepositBalanceEth = await client.getBalance({
@@ -317,12 +309,10 @@ test.describe('Bridge', () => {
         account.address,
       ])) as BigNumberish;
 
-      await test.step('Go to deposit tab', async () => {
+      await test.step('Faucet ERC-20', async () => {
         await goToBridgePage(page);
         await clickDepositTab(page);
-      });
 
-      await test.step('Faucet ERC-20', async () => {
         const coinSelector = getByAriaLabel(page, 'Coin Selector');
         await coinSelector.click();
 
@@ -388,19 +378,14 @@ test.describe('Bridge', () => {
       });
 
       await test.step('Check transaction submitted to ETH network', async () => {
-        // Check if has loading state on dialog
-        const loading = getByAriaLabel(page, 'Loading Transaction Info');
-        expect((await loading.allInnerTexts()).length).toBe(2);
-
         await page.locator(':nth-match(:text("Done"), 1)').waitFor();
 
         // Check toast success feedback of tx created
         await hasText(page, INITIATE_DEPOSIT);
+        await page.locator(':nth-match(:text("Done"), 2)').waitFor();
       });
 
       await test.step('Check ETH balance reduced', async () => {
-        await page.locator(':nth-match(:text("Done"), 2)').waitFor();
-
         const postDepositBalanceEth = await erc20Contract.read.balanceOf([
           account.address,
         ]);
@@ -424,7 +409,7 @@ test.describe('Bridge', () => {
       });
 
       let depositTxLocator;
-      await test.step('Check withdraw tx in the Tx list and open popup', async () => {
+      await test.step('Check deposit tx in the Tx list and open popup', async () => {
         await closeTransactionPopup(page);
         await goToTransactionsPage(page);
 

--- a/packages/app/playwright/e2e/Bridge.test.ts
+++ b/packages/app/playwright/e2e/Bridge.test.ts
@@ -284,7 +284,6 @@ test.describe('Bridge', () => {
           BaseAssetId
         );
 
-        // We only divide by 15 bc bigint does not support decimals
         expect(
           parseFloat(
             bn(postWithdrawBalanceEth.toString())

--- a/packages/app/playwright/e2e/utils/bridge.ts
+++ b/packages/app/playwright/e2e/utils/bridge.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 
+import { shortAddress } from '../../../src/systems/Core/utils';
 import { getButtonByText, getByAriaLabel } from '../../commons';
 
 export async function closeTransactionPopup(page: Page) {
@@ -29,4 +30,16 @@ export const clickDepositTab = async (page: Page) => {
 export const clickWithdrawTab = async (page: Page) => {
   const tab = getButtonByText(page, 'Withdraw from Fuel');
   await tab.click();
+};
+
+export const checkTxItemDone = async (page: Page, txHash: string) => {
+  const listItem = getByAriaLabel(
+    page,
+    `Transaction ID: ${shortAddress(txHash)}`
+  );
+  const listItemText = await listItem.innerText();
+  expect(listItemText).toBeTruthy();
+  const settled = listItem.getByText('Settled');
+  const settledText = await settled.innerText();
+  expect(settledText).toBeTruthy();
 };

--- a/packages/app/playwright/e2e/utils/bridge.ts
+++ b/packages/app/playwright/e2e/utils/bridge.ts
@@ -1,8 +1,32 @@
-import type { Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
-import { getByAriaLabel } from '../../commons';
+import { getButtonByText, getByAriaLabel } from '../../commons';
 
 export async function closeTransactionPopup(page: Page) {
   const popupTransactino = getByAriaLabel(page, 'Close Transaction Dialog');
   await popupTransactino.click();
 }
+
+export const hasDropdownSymbol = async (page: Page, symbol: string) => {
+  const assetDropdown = getByAriaLabel(page, 'Coin Selector').getByText(symbol);
+  expect(await assetDropdown.innerText()).toBe(symbol);
+};
+
+export const goToBridgePage = async (page: Page) => {
+  const bridgeButton = page.locator('button').getByText('Bridge');
+  await bridgeButton.click();
+};
+export const goToTransactionsPage = async (page: Page) => {
+  const transactionList = page.locator('button').getByText('History');
+  await transactionList.click();
+};
+
+export const clickDepositTab = async (page: Page) => {
+  const tab = getButtonByText(page, 'Deposit to Fuel');
+  await tab.click();
+};
+
+export const clickWithdrawTab = async (page: Page) => {
+  const tab = getButtonByText(page, 'Withdraw from Fuel');
+  await tab.click();
+};

--- a/packages/app/src/systems/Accounts/components/AccountConnectionInput/AccountConnectionInput.tsx
+++ b/packages/app/src/systems/Accounts/components/AccountConnectionInput/AccountConnectionInput.tsx
@@ -76,7 +76,7 @@ export const AccountConnectionInput = ({
                 >
                   Disconnect
                 </Button>
-                <Text>
+                <Text aria-label={`${networkName}: Connected Wallet`}>
                   {shortAddress(account.alias, {
                     minLength: 16,
                   }) ||

--- a/packages/app/src/systems/Bridge/components/BridgeSteps/BridgeSteps.tsx
+++ b/packages/app/src/systems/Bridge/components/BridgeSteps/BridgeSteps.tsx
@@ -46,7 +46,12 @@ export const BridgeSteps = ({ steps }: BridgeStepsProps) => {
             </Box.Flex>
             <Box.Flex align="center" gap="$1">
               {step.isLoading && <Spinner size={14} />}
-              <Text fontSize="sm">{step.status}</Text>
+              <Text
+                fontSize="sm"
+                aria-label={`Step ${step.name?.toString()}: ${step.status}`}
+              >
+                {step.status}
+              </Text>
             </Box.Flex>
           </Box.Flex>
         );

--- a/packages/app/src/systems/Bridge/components/BridgeTxItem/BridgeTxItem.tsx
+++ b/packages/app/src/systems/Bridge/components/BridgeTxItem/BridgeTxItem.tsx
@@ -59,7 +59,12 @@ export const BridgeTxItem = ({
         ) : (
           <Text css={styles.ageText}>{calculateDateDiff(date)}</Text>
         )}
-        <Box.Flex css={styles.statusColumn} align="center" justify="flex-end">
+        <Box.Flex
+          css={styles.statusColumn}
+          align="center"
+          justify="flex-end"
+          aria-label={`Transaction Status: ${status?.toString()}`}
+        >
           {status}
         </Box.Flex>
       </Box.Flex>

--- a/packages/app/src/systems/Bridge/components/BridgeTxItem/ItemLoader.tsx
+++ b/packages/app/src/systems/Bridge/components/BridgeTxItem/ItemLoader.tsx
@@ -2,7 +2,12 @@ import { ContentLoader } from '@fuel-ui/react';
 
 export const ItemLoader = () => {
   return (
-    <ContentLoader speed={2} height="18" width="70">
+    <ContentLoader
+      speed={2}
+      height="18"
+      width="70"
+      aria-label="Loading Transaction List Item"
+    >
       <ContentLoader.Rect width="90" height="18" rx="4" />
     </ContentLoader>
   );

--- a/packages/app/src/systems/Bridge/components/BridgeTxItemsLoading/BridgeTxItemsLoading.tsx
+++ b/packages/app/src/systems/Bridge/components/BridgeTxItemsLoading/BridgeTxItemsLoading.tsx
@@ -7,7 +7,11 @@ export const BridgeTxItemsLoading = () => {
 
   const currentColors = theme === 'light' ? lightColors : darkColors;
   return (
-    <Box.Stack justify="center" gap="$4">
+    <Box.Stack
+      justify="center"
+      gap="$4"
+      aria-label="Loading Bridge Transactions"
+    >
       <ContentLoader
         speed={2}
         height="58"

--- a/packages/app/src/systems/Bridge/components/BridgeTxOverview/InfoTextLoader.tsx
+++ b/packages/app/src/systems/Bridge/components/BridgeTxOverview/InfoTextLoader.tsx
@@ -2,7 +2,12 @@ import { ContentLoader } from '@fuel-ui/react';
 
 export const InfoTextLoader = () => {
   return (
-    <ContentLoader speed={2} height="18" width="70">
+    <ContentLoader
+      speed={2}
+      height="18"
+      width="70"
+      aria-label="Loading Transaction Info"
+    >
       <ContentLoader.Rect width="70" height="18" rx="4" />
     </ContentLoader>
   );

--- a/packages/app/src/systems/Bridge/containers/BridgeTabs.tsx
+++ b/packages/app/src/systems/Bridge/containers/BridgeTabs.tsx
@@ -34,7 +34,7 @@ export const BridgeTabs = ({ fromControls, toControls }: BridgeTabsProps) => {
   };
 
   return (
-    <Tabs defaultValue={isWithdraw ? 'withdraw' : 'deposit'} variant="subtle">
+    <Tabs value={isWithdraw ? 'withdraw' : 'deposit'} variant="subtle">
       <Tabs.List aria-label="Manage deposits">
         <Tabs.Trigger
           value="deposit"


### PR DESCRIPTION
Closes #163 
Closes FRO-651

## Bugfix
Bug when clicking to withdraw under this situation:
- Select withdraw Tab > Click in Transaction Tab > Click in Bridge Tab. 
- Withdraw tab will be selected, but with deposit data in the form.


## Improve E2E testing

### Refact / subgroups
As tests are sometimes flaky and long, it's hard to debug where is the problem
To solve this:
- Splitted more the tests into subgroups
- Described better each steps
- Isolated wallet approvals

### Increase scenarios coverage
UX experience:
- test loading state in deposit dialog
- skip test loading state in withdraw dialog (FUEL blazingly fast)
- check if TX is settled on list after transaction
- check assets in selector over the process
- check time left shown in withdraw popups
- check TX list after refreshing, all transactions made should be "Settled"
- check if bridge page after refreshing, is still connected to same wallet and has same balance