### PR TITLE
fix: request limit

### DIFF
--- a/packages/app/src/providers.tsx
+++ b/packages/app/src/providers.tsx
@@ -7,6 +7,7 @@ import {
   FuelUiProvider,
   FuelConnectProvider,
 } from './systems/Settings';
+import { FuelNetworkProvider } from './systems/Settings/providers/FuelNetworkProvider';
 
 type ProvidersProps = {
   children: ReactNode;
@@ -18,7 +19,9 @@ export function Providers({ children }: ProvidersProps) {
       <FuelProvider>
         <FuelConnectProvider>
           <ConnectProvider>
-            <FuelUiProvider>{children}</FuelUiProvider>
+            <FuelUiProvider>
+              <FuelNetworkProvider>{children}</FuelNetworkProvider>
+            </FuelUiProvider>
           </ConnectProvider>
         </FuelConnectProvider>
       </FuelProvider>

--- a/packages/app/src/systems/Bridge/hooks/useBridge.tsx
+++ b/packages/app/src/systems/Bridge/hooks/useBridge.tsx
@@ -1,4 +1,3 @@
-import type { FuelWalletLocked } from '@fuel-wallet/sdk';
 import type { BN } from 'fuels';
 import { bn, DECIMAL_UNITS } from 'fuels';
 import { useEffect, useMemo } from 'react';
@@ -96,6 +95,7 @@ export function useBridge() {
     isConnecting: fuelIsConnecting,
     balance: fuelBalance,
     wallet: fuelWallet,
+    provider: fuelProvider,
   } = useFuelAccountConnection({
     assetId: fuelAssetAddress?.startsWith('0x')
       ? (fuelAssetAddress as `0x${string}`)
@@ -213,8 +213,8 @@ export function useBridge() {
         store.startBridging({
           fuelAddress,
           ethWalletClient,
-          // TODO: remove this workaround when we get versions organized and using the same version
-          fuelWallet: fuelWallet as unknown as FuelWalletLocked,
+          fuelWallet,
+          fuelProvider,
           ethAddress,
           asset,
           ethPublicClient,

--- a/packages/app/src/systems/Bridge/machines/bridgeMachine.tsx
+++ b/packages/app/src/systems/Bridge/machines/bridgeMachine.tsx
@@ -95,6 +95,7 @@ export const bridgeMachine = createMachine(
               fuelWallet: ev.input.fuelWallet,
               ethAddress: ev.input.ethAddress,
               fuelAsset: ev.input.fuelAsset,
+              fuelProvider: ev.input.fuelProvider,
             }),
           },
           onDone: [

--- a/packages/app/src/systems/Bridge/services/bridge.tsx
+++ b/packages/app/src/systems/Bridge/services/bridge.tsx
@@ -56,6 +56,7 @@ export class BridgeService {
       fuelWallet,
       ethAddress,
       asset,
+      fuelProvider,
     } = input;
 
     if (!fromNetwork || !toNetwork) {
@@ -90,7 +91,7 @@ export class BridgeService {
         if (fuelWallet) {
           store.addTxEthToFuel({
             ethTxId: txId,
-            fuelProvider: fuelWallet.provider,
+            fuelProvider,
             ethPublicClient,
             fuelAddress,
           });
@@ -111,13 +112,14 @@ export class BridgeService {
         fuelWallet,
         ethAddress,
         fuelAsset,
+        fuelProvider,
       });
 
       if (txId) {
         if (fuelWallet) {
           store.addTxFuelToEth({
             fuelTxId: txId,
-            fuelProvider: fuelWallet.provider,
+            fuelProvider,
             ethPublicClient,
           });
           store.openTxFuelToEth({

--- a/packages/app/src/systems/Chains/eth/services/txEthToFuel.ts
+++ b/packages/app/src/systems/Chains/eth/services/txEthToFuel.ts
@@ -3,13 +3,9 @@ import type {
   Message,
   WalletUnlocked as FuelWallet,
   TransactionResponse,
-} from 'fuels';
-import {
   Provider as FuelProvider,
-  Address as FuelAddress,
-  bn,
-  ZeroBytes32,
 } from 'fuels';
+import { Address as FuelAddress, bn, ZeroBytes32 } from 'fuels';
 import type { WalletClient } from 'viem';
 import { decodeEventLog } from 'viem';
 import type { PublicClient } from 'wagmi';
@@ -328,10 +324,7 @@ export class TxEthToFuelService {
     }
 
     const { fuelProvider, ethTxNonce } = input;
-
-    // TODO: should use the fuelProvider from input when wallet gets updated with new SDK
-    const provider = await FuelProvider.create(fuelProvider.url);
-    const messageStatus = await provider.getMessageStatus(
+    const messageStatus = await fuelProvider.getMessageStatus(
       ethTxNonce.toHex(32).toString()
     );
     return messageStatus;
@@ -350,9 +343,7 @@ export class TxEthToFuelService {
 
     const { ethTxNonce, fuelProvider, fuelRecipient } = input;
 
-    // TODO: should use the fuelProvider from input when wallet gets updated with new SDK
-    const provider = await FuelProvider.create(fuelProvider.url);
-    const messages = await provider.getMessages(fuelRecipient, {
+    const messages = await fuelProvider.getMessages(fuelRecipient, {
       first: 1000,
     });
     const fuelMessage = messages.find((message) => {
@@ -373,9 +364,7 @@ export class TxEthToFuelService {
     }
     const { fuelWallet, fuelMessage } = input;
 
-    // TODO: should use the fuelProvider from input when wallet gets updated with new SDK
-    const provider = await FuelProvider.create(fuelWallet.provider.url);
-    const { maxGasPerTx } = await provider.getGasConfig();
+    const { maxGasPerTx } = await input.fuelWallet.provider.getGasConfig();
     let txMessageRelayed: TransactionResponse | undefined;
     try {
       txMessageRelayed = await relayCommonMessage({

--- a/packages/app/src/systems/Chains/fuel/hooks/useBalance.tsx
+++ b/packages/app/src/systems/Chains/fuel/hooks/useBalance.tsx
@@ -1,0 +1,54 @@
+import { QUERY_KEYS } from '@fuel-wallet/react';
+import { useQuery } from '@tanstack/react-query';
+// should import BN because of this error: https://github.com/FuelLabs/fuels-ts/issues/1054
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { BytesLike, BN, Provider as FuelProvider } from 'fuels';
+import { Address } from 'fuels';
+import { useEffect } from 'react';
+
+export const useBalance = ({
+  address,
+  assetId,
+  provider,
+}: {
+  address?: string;
+  assetId?: BytesLike;
+  provider?: FuelProvider;
+}) => {
+  const query = useQuery(
+    [QUERY_KEYS.balance, address, assetId],
+    async () => {
+      try {
+        // TODO: replace with ETH_ASSET_ID from asset-list package after this task gets done
+        // https://linear.app/fuel-network/issue/FRO-144/make-asset-list-package-public-and-publish-in-npm
+        const currentFuelBalance = await provider?.getBalance(
+          Address.fromString(address || ''),
+          assetId ||
+            '0x0000000000000000000000000000000000000000000000000000000000000000'
+        );
+        return currentFuelBalance || null;
+      } catch (error: unknown) {
+        return null;
+      }
+    },
+    {
+      enabled: !!provider,
+    }
+  );
+
+  const listenerAccountFetcher = () => {
+    query.refetch();
+  };
+
+  useEffect(() => {
+    window.addEventListener('focus', listenerAccountFetcher);
+    return () => {
+      window.removeEventListener('focus', listenerAccountFetcher);
+    };
+  }, []);
+
+  return {
+    balance: query.data || undefined,
+    ...query,
+  };
+};

--- a/packages/app/src/systems/Chains/fuel/hooks/useFuelAccountConnection.tsx
+++ b/packages/app/src/systems/Chains/fuel/hooks/useFuelAccountConnection.tsx
@@ -2,8 +2,6 @@ import {
   useAccount,
   useDisconnect,
   useIsConnected,
-  useProvider,
-  useBalance,
   useWallet,
   useConnector,
   useFuel,
@@ -12,22 +10,26 @@ import { Address } from 'fuels';
 import { useMemo } from 'react';
 import { store } from '~/store';
 import type { AssetFuel } from '~/systems/Assets/utils';
+import { useFuelNetwork } from '~/systems/Settings/providers/FuelNetworkProvider';
 
+import { useBalance } from './useBalance';
 import { useHasFuelWallet } from './useHasFuelWallet';
 
 export const useFuelAccountConnection = (props?: { assetId?: string }) => {
   const { assetId } = props || {};
+  const { fuelProvider } = useFuelNetwork();
   const { fuel } = useFuel();
   const { account } = useAccount();
   const { balance } = useBalance({
     address: account || '',
     assetId,
+    provider: fuelProvider,
   });
   const { hasWallet } = useHasFuelWallet();
   const { isConnected, isLoading: isLoadingConnection } = useIsConnected();
   const { connect, error, isConnecting } = useConnector();
   const { disconnect } = useDisconnect();
-  const { provider } = useProvider();
+  // const { provider: fuelProvider } = useProvider();
   const { wallet } = useWallet({ address: account || '' });
 
   const address = useMemo(
@@ -61,7 +63,7 @@ export const useFuelAccountConnection = (props?: { assetId?: string }) => {
     hasWallet,
     isLoadingConnection,
     isConnecting,
-    provider,
+    provider: fuelProvider,
     balance,
     wallet,
   };

--- a/packages/app/src/systems/Chains/fuel/utils/provider.ts
+++ b/packages/app/src/systems/Chains/fuel/utils/provider.ts
@@ -2,7 +2,7 @@ import type { FetchRequestOptions } from 'fuels';
 import { Provider } from 'fuels';
 
 let requestTimestamps: number[] = [];
-const maxRequestsPerSecond = 10;
+const maxRequestsPerSecond = 20;
 const waitTime = 1000; // 1 second in milliseconds
 
 export const rateLimitedFetch = async (

--- a/packages/app/src/systems/Chains/fuel/utils/provider.ts
+++ b/packages/app/src/systems/Chains/fuel/utils/provider.ts
@@ -1,0 +1,38 @@
+import type { FetchRequestOptions } from 'fuels';
+import { Provider } from 'fuels';
+
+let requestTimestamps: number[] = [];
+const maxRequestsPerSecond = 10;
+const waitTime = 1000; // 1 second in milliseconds
+
+export const rateLimitedFetch = async (
+  url: string,
+  options: FetchRequestOptions
+): Promise<Response> => {
+  const now = Date.now();
+  requestTimestamps = requestTimestamps.filter(
+    (timestamp) => now - timestamp < waitTime
+  );
+
+  if (requestTimestamps.length >= maxRequestsPerSecond) {
+    console.log(
+      `Reached the rate limit of ${maxRequestsPerSecond} requests per second. Waiting for 1 second...`
+    );
+    await new Promise((resolve) => setTimeout(resolve, waitTime));
+    console.log('Done waiting. Resuming requests...');
+    // Do not clear the request timestamps. Rely on the filter to remove old ones.
+    // Call the function recursively to recheck the limit
+    return rateLimitedFetch(url, options);
+  }
+
+  // Add a new timestamp for the current request
+  requestTimestamps.push(Date.now());
+
+  // Finally, perform the fetch operation
+  return fetch(url, options);
+};
+
+export async function createProvider(url: string) {
+  const provider = await Provider.create(url, { fetch: rateLimitedFetch });
+  return provider;
+}

--- a/packages/app/src/systems/Chains/fuel/utils/relayMessage.ts
+++ b/packages/app/src/systems/Chains/fuel/utils/relayMessage.ts
@@ -7,6 +7,7 @@ import type {
   WalletUnlocked as FuelWallet,
   TransactionRequestLike,
   TransactionResponse,
+  Provider,
 } from 'fuels';
 import {
   ZeroBytes32,
@@ -17,7 +18,6 @@ import {
   OutputType,
   Predicate,
   bn,
-  Provider,
 } from 'fuels';
 
 import { resourcesToInputs } from './transaction';
@@ -135,10 +135,7 @@ export async function relayCommonMessage({
   const predicateRoot = message.recipient.toHexString();
 
   // eslint-disable-next-line no-restricted-syntax
-
-  // TODO: should use the fuelProvider from input when wallet gets updated with new SDK
-  const provider = await Provider.create(relayer.provider.url);
-  for (const details of getCommonRelayableMessages(provider)) {
+  for (const details of getCommonRelayableMessages(relayer.provider)) {
     if (details.predicateRoot.toLowerCase() === predicateRoot.toLowerCase()) {
       messageRelayDetails = details;
       break;

--- a/packages/app/src/systems/Settings/providers/FuelNetworkProvider.tsx
+++ b/packages/app/src/systems/Settings/providers/FuelNetworkProvider.tsx
@@ -1,0 +1,42 @@
+import type { Provider } from 'fuels';
+import type { ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { FUEL_CHAIN } from '~/systems/Chains/config';
+import { createProvider } from '~/systems/Chains/fuel/utils/provider';
+
+type FuelNetworkProviderProps = {
+  children?: ReactNode;
+};
+
+export type FuelReactContextType = {
+  fuelProvider: Provider | undefined;
+};
+
+export const FuelReactContext = createContext<FuelReactContextType | null>(
+  null
+);
+
+export const useFuelNetwork = () => {
+  return useContext(FuelReactContext) as FuelReactContextType;
+};
+
+export const FuelNetworkProvider = ({ children }: FuelNetworkProviderProps) => {
+  const [fuelProvider, setFuelProvider] = useState<Provider | undefined>();
+
+  useEffect(() => {
+    if (fuelProvider) return;
+
+    async function getFuelProvider() {
+      const provider = await createProvider(FUEL_CHAIN.providerUrl);
+      setFuelProvider(provider);
+    }
+
+    getFuelProvider();
+  }, [fuelProvider]);
+
+  return (
+    <FuelReactContext.Provider value={{ fuelProvider }}>
+      {children}
+    </FuelReactContext.Provider>
+  );
+};

--- a/scripts/deps.sh
+++ b/scripts/deps.sh
@@ -9,7 +9,7 @@
 # Figure out dependencies to link
 deps=""
 if [ "$LINK_FUEL_TS" = true ]; then
-	fuel_ts_deps="fuels"
+	fuel_ts_deps="fuels @fuel-ts/utils"
 	deps="$deps $fuel_ts_deps"
 fi
 


### PR DESCRIPTION
Features
- Create a provider for the bridge to use the same instance everywhere
- Apply a rate limiter to this provider



side effects
- Fix all places to use the correct provider
- Override the `useBalance` hook from `@fuels-wallet/react` package, to be able to use bridge provider

Closes #189 